### PR TITLE
fix(fields): the timestamp is spelled @timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix the binary name from sekoia-event-export to sekoia-event-exporter in Readme
+- Fix the timestamp default field name
 
 ### Security
 - Nothing yet

--- a/README.md
+++ b/README.md
@@ -278,14 +278,14 @@ sekoia-event-exporter export 550e8400-e29b-41d4-a716-446655440000
 
 **Specify fields to export:**
 
-By default, only `message` and `timestamp` fields are exported to avoid exporting unnecessary data. You can specify additional fields:
+By default, only `message` and `@timestamp` fields are exported to avoid exporting unnecessary data. You can specify additional fields:
 
 ```bash
 # Export specific fields
-sekoia-event-exporter export <job_uuid> --fields "message,timestamp,source.ip,destination.ip"
+sekoia-event-exporter export <job_uuid> --fields "message,@timestamp,source.ip,destination.ip"
 
 # Or using environment variable
-export EXPORT_FIELDS="message,timestamp,source.ip,user.name"
+export EXPORT_FIELDS="message,@timestamp,source.ip,user.name"
 sekoia-event-exporter export <job_uuid>
 ```
 
@@ -377,7 +377,7 @@ sekoia-event-exporter download <task_uuid> -o my-export.json.gz
 - `--max-wait`: Maximum wait time in seconds (default: no limit)
 - `--no-download`: Don't download the file, just print the URL
 - `--output`, `-o`: Output filename for the downloaded file (default: export_YYYYMMDD_HHMMSS.json.gz)
-- `--fields`: Comma-separated list of fields to export (default: message,timestamp, overrides EXPORT_FIELDS env var)
+- `--fields`: Comma-separated list of fields to export (default: message,@timestamp, overrides EXPORT_FIELDS env var)
 
 **S3 Configuration:**
 - `--s3-bucket`: S3 bucket name (overrides S3_BUCKET env var)

--- a/src/sekoia_event_exporter/cli.py
+++ b/src/sekoia_event_exporter/cli.py
@@ -28,7 +28,7 @@ from . import __version__
 DEFAULT_API_HOST = "api.sekoia.io"
 DEFAULT_INTERVAL_S = 2
 DEFAULT_TIMEOUT = (5, 30)  # (connect, read)
-DEFAULT_EXPORT_FIELDS = ["message", "timestamp"]  # Default fields to export
+DEFAULT_EXPORT_FIELDS = ["message", "@timestamp"]  # Default fields to export
 
 
 class ConfigError(RuntimeError):
@@ -178,13 +178,13 @@ def get_export_fields(fields_arg: str | None = None) -> list[str]:
     Priority:
         1. Command-line argument (--fields)
         2. Environment variable (EXPORT_FIELDS)
-        3. Default fields (message, timestamp)
+        3. Default fields (message, @timestamp)
 
     Example:
-        >>> get_export_fields("message,timestamp,source.ip")
-        ['message', 'timestamp', 'source.ip']
+        >>> get_export_fields("message,@timestamp,source.ip")
+        ['message', '@timestamp', 'source.ip']
         >>> get_export_fields()  # Uses defaults
-        ['message', 'timestamp']
+        ['message', '@timestamp']
     """
     # Check command-line argument first
     if fields_arg:
@@ -781,7 +781,7 @@ def main() -> None:
         "--fields",
         type=str,
         default=None,
-        help="Comma-separated list of fields to export (default: message,timestamp, overrides EXPORT_FIELDS env var)",
+        help="Comma-separated list of fields to export (default: message,@timestamp, overrides EXPORT_FIELDS env var)",
     )
 
     # S3 Configuration


### PR DESCRIPTION
This pull request updates the default exported fields in the event export tool from `timestamp` to `@timestamp` for improved accuracy and consistency. The changes ensure that both the documentation and code use `@timestamp` as the default field alongside `message`.

**Default export fields update:**

* Updated the default export fields from `["message", "timestamp"]` to `["message", "@timestamp"]` in `DEFAULT_EXPORT_FIELDS` in `src/sekoia_event_exporter/cli.py`.
* Updated the fallback/default fields in the `get_export_fields` function and its docstring to use `@timestamp` instead of `timestamp` in `src/sekoia_event_exporter/cli.py`.

**Documentation updates:**

* Updated all relevant examples and descriptions in `README.md` to use `@timestamp` instead of `timestamp` as the default field. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L281-R288) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L380-R380)
* Updated the help text for the `--fields` command-line argument to reflect the new default in `src/sekoia_event_exporter/cli.py`.