### PR TITLE
ci: Harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Cooldown applies only to version updates, not security updates
+    cooldown:
+      default-days: 14
+    groups:
+      # Group all version updates into a single PR; security updates remain ungrouped
+      github-actions:
+        applies-to: version-updates
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       if: matrix.python-version == '3.13'
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false
 
   code-quality:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,12 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions: {}
+
 jobs:
   test:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     name: Test Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
     strategy:
@@ -44,6 +48,8 @@ jobs:
         fail_ci_if_error: false
 
   code-quality:
+    permissions:
+      contents: read  # for actions/checkout to fetch code
     name: Code Quality
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,15 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
       with:
         enable-cache: true
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -38,7 +38,7 @@ jobs:
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.13'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
       with:
         file: ./coverage.xml
         fail_ci_if_error: false
@@ -48,15 +48,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
       with:
         enable-cache: true
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.13"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,15 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   build-and-publish:
+    permissions:
+      contents: write  # for softprops/action-gh-release to create GitHub release
+      id-token: write  # for pypa/gh-action-pypi-publish to use trusted publishing
     name: Build and publish to PyPI
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write  # Required for trusted publishing
-      contents: write  # Required for uploading release assets
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,13 +13,13 @@ jobs:
       contents: write  # Required for uploading release assets
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v4
+      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: "3.13"
 
@@ -37,11 +37,11 @@ jobs:
       run: uv build
 
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
       with:
         verbose: true
 
     - name: Create GitHub Release Assets
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0
       with:
         files: dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+      with:
+        enable-cache: false
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
## Summary

- Configure Dependabot for GitHub Actions (weekly, 14-day cooldown, grouped version updates)
- Pin actions to commit SHAs (14-day minimum age)
- Least-privilege `permissions` (deny-all at workflow level, minimal job-level grants)
- Fix zizmor findings (disable cache in publish workflow to prevent cache poisoning)
- Migrate codecov-action deprecated `file` input to `files`

### Action version upgrades

Pinning to SHAs also upgrades actions to their latest major versions:

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v6.0.2 |
| `astral-sh/setup-uv` | v4 | v7.3.1 |
| `actions/setup-python` | v5 | v6.2.0 |
| `codecov/codecov-action` | v4 | v5.5.2 |
| `softprops/action-gh-release` | v1 | v2.5.0 |
| `pypa/gh-action-pypi-publish` | release/v1 | v1.13.0 |

Breaking changes are Node 24 / runner version requirements (compatible with GitHub-hosted runners).