### PR TITLE
fix: Retry to fetch task status on specifc errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 - Nothing yet
 
+## [0.5.4] - 2026-05-26
+
+### Fixed
+- Retry when retrieving the task fails with a 503 or a 504 error
+
 ## [0.5.3] - 2026-02-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sekoia-event-exporter"
-version = "0.5.3"
+version = "0.5.4"
 description = "Export search job results from Sekoia.io API"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -30,6 +30,7 @@ classifiers = [
 ]
 dependencies = [
     "requests>=2.28.0",
+    "tenacity>=9.1.4",
 ]
 
 [project.optional-dependencies]

--- a/src/sekoia_event_exporter/cli.py
+++ b/src/sekoia_event_exporter/cli.py
@@ -22,6 +22,7 @@ import time
 from datetime import datetime, timedelta
 
 import requests
+from tenacity import RetryCallState, retry, retry_if_exception, stop_after_attempt, wait_exponential
 
 from . import __version__
 
@@ -467,6 +468,33 @@ def download_file(
         raise RuntimeError(f"Failed to download file: {e}") from e
 
 
+def _is_retryable_http_error(exc: BaseException) -> bool:
+    return isinstance(exc, requests.HTTPError) and exc.response is not None and exc.response.status_code in (503, 504)
+
+
+def _before_retry(retry_state: RetryCallState):
+    print(f"\nFailed to fetch task status (attempt {retry_state.attempt_number}). Retrying...")
+
+
+@retry(
+    retry=retry_if_exception(_is_retryable_http_error),
+    wait=wait_exponential(multiplier=1, min=2, max=30),
+    stop=stop_after_attempt(5),
+    reraise=True,
+    before_sleep=_before_retry,
+)
+def _fetch_task_request(
+    task_uuid: str,
+    session: requests.Session,
+    api_host: str,
+    timeout: tuple[int, int],
+) -> dict:
+    url = f"https://{api_host}/v1/tasks/{task_uuid}"
+    resp = session.get(url, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
 def fetch_task(task_uuid: str, session: requests.Session, api_host: str, timeout=DEFAULT_TIMEOUT) -> dict:
     """Fetch the current status of an export task.
 
@@ -482,11 +510,10 @@ def fetch_task(task_uuid: str, session: requests.Session, api_host: str, timeout
     Raises:
         RuntimeError: If fetching the task status fails.
     """
-    url = f"https://{api_host}/v1/tasks/{task_uuid}"
-    resp = session.get(url, timeout=timeout)
-    if resp.status_code != 200:
-        raise RuntimeError(f"Failed to get export status: {resp.status_code} {resp.text}")
-    return resp.json()
+    try:
+        return _fetch_task_request(task_uuid, session, api_host, timeout)
+    except requests.HTTPError as e:
+        raise RuntimeError(f"Failed to get export status: {e.response.status_code} {e.response.text}") from e
 
 
 def poll_status(

--- a/uv.lock
+++ b/uv.lock
@@ -495,10 +495,11 @@ wheels = [
 
 [[package]]
 name = "sekoia-event-exporter"
-version = "0.5.1"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "requests" },
+    { name = "tenacity" },
 ]
 
 [package.optional-dependencies]
@@ -517,9 +518,19 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "requests", specifier = ">=2.28.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "tenacity", specifier = ">=9.1.4" },
     { name = "types-requests", marker = "extra == 'dev'", specifier = ">=2.28.0" },
 ]
 provides-extras = ["dev"]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
 
 [[package]]
 name = "tomli"


### PR DESCRIPTION
Retry fetching task status on server errors. A failure in retrieving the status once doesn't mean the export job  failed since both of them are located in 2 distinct services.